### PR TITLE
Make `view` return a view of the underlying buffer

### DIFF
--- a/src/CircularArrayBuffers.jl
+++ b/src/CircularArrayBuffers.jl
@@ -50,6 +50,9 @@ Base.getindex(cb::CircularArrayBuffer{T,N}, I...) where {T,N} = getindex(cb.buff
 Base.setindex!(cb::CircularArrayBuffer{T,N}, v, i::Int) where {T,N} = setindex!(cb.buffer, v, _buffer_index(cb, i))
 Base.setindex!(cb::CircularArrayBuffer{T,N}, v, I...) where {T,N} = setindex!(cb.buffer, v, Base.front(I)..., _buffer_frame(cb, Base.last(I)))
 
+Base.view(cb::CircularArrayBuffer, i::Int) = view(cb.buffer, _buffer_index(cb, i))
+Base.view(cb::CircularArrayBuffer, I...) = view(cb.buffer, Base.front(I)..., _buffer_frame(cb, Base.last(I)))
+
 capacity(cb::CircularArrayBuffer{T,N}) where {T,N} = size(cb.buffer, N)
 isfull(cb::CircularArrayBuffer) = cb.nframes == capacity(cb)
 Base.isempty(cb::CircularArrayBuffer) = cb.nframes == 0


### PR DESCRIPTION
This adds a custom `view` that returns a view of the buffer instead of a view of the `CircularArrayBuffer` (matching the behavior of `getindex`). This is needed to do zero-copy operations on the buffer while using CUDA.jl.