### PR TITLE
Clarify _buffer_index behavior

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,19 @@
 name = "CircularArrayBuffers"
 uuid = "9de3a189-e0c0-4e15-ba3b-b14b9fb0aec1"
 authors = ["Jun Tian <tianjun.cpp@gmail.com> and contributors"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
 Adapt = "2, 3, 4"
 julia = "1"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["CUDA", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -231,7 +231,7 @@ if CUDA.functional()
             @test isempty(b) == true
             @test length(b) == 0
             @test size(b) == (0,)
-            # element must has the exact same length with the element of buffer
+            # element must have the exact same length with the element of buffer
             @test_throws Exception push!(b, [1, 2])
 
             for x in 1:3


### PR DESCRIPTION
This pull request clarifies the behavior of the `_buffer_index` function in the CircularArrayBuffer module. It adds a new function `wrap_index` to handle index wrapping when it exceeds the buffer size. The changes also include updated comments.