### PR TITLE
"Fix bounds error in CircularArrayBuffer"

### DIFF
--- a/src/CircularArrayBuffers.jl
+++ b/src/CircularArrayBuffers.jl
@@ -45,7 +45,7 @@ Base.IndexStyle(::CircularArrayBuffer) = IndexLinear()
 
 Base.size(cb::CircularArrayBuffer{T,N}, i::Integer) where {T,N} = i == N ? cb.nframes : size(cb.buffer, i)
 Base.size(cb::CircularArrayBuffer{T,N}) where {T,N} = ntuple(i -> size(cb, i), N)
-Base.getindex(cb::CircularArrayBuffer{T,N}, i::Int) where {T,N} = getindex(cb.buffer, _buffer_index(cb, i))
+Base.getindex(cb::CircularArrayBuffer{T,N}, i::Int) where {T,N} = (@boundscheck checkbounds(cb, i); getindex(cb.buffer, _buffer_index(cb, i)))
 Base.getindex(cb::CircularArrayBuffer{T,N}, I...) where {T,N} = getindex(cb.buffer, Base.front(I)..., _buffer_frame(cb, Base.last(I)))
 
 # !!!

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,15 @@ CUDA.allowscalar(false)
         @test_throws BoundsError @view b[:, 9]
     end
 
+    @testset "Bounds error for zero-length buffer" begin
+        b = CircularVectorBuffer{Bool}(10)
+        @test_throws BoundsError b[end]
+        for i in 1:5
+            push!(b, true)
+        end
+        @test b[end] == true
+    end
+    
     @testset "1D vector" begin
         b = CircularArrayBuffer([[1], [2, 3]])
         push!(b, [4, 5, 6])


### PR DESCRIPTION
"This pull request fixes a bounds error in the CircularArrayBuffer implementation. The getindex function now includes bounds checking to prevent accessing elements outside the buffer's range. Additionally, a test case for a zero-length buffer has been added to ensure correct behavior.